### PR TITLE
added /raycount command, and ray count / probability infos added to /info

### DIFF
--- a/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -18,18 +18,17 @@
  {
      private static final Logger LOGGER = LogManager.getLogger();
      private String language = "en_US";
-@@ -151,6 +154,10 @@
+@@ -151,6 +154,9 @@
      public int ping;
      public boolean queuedEndExit;
  
 +    //CM
 +    public EntityPlayerActionPack actionPack;
-+    public BlockPos posToCheckRaycount = null;
 +
      public EntityPlayerMP(MinecraftServer server, WorldServer worldIn, GameProfile profile, PlayerInteractionManager interactionManagerIn)
      {
          super(worldIn, profile);
-@@ -162,6 +169,9 @@
+@@ -162,6 +168,9 @@
          this.advancements = server.getPlayerList().getPlayerAdvancements(this);
          this.stepHeight = 1.0F;
          this.func_205734_a(worldIn);
@@ -39,7 +38,7 @@
      }
  
      private void func_205734_a(WorldServer p_205734_1_)
-@@ -337,6 +347,9 @@
+@@ -337,6 +346,9 @@
  
      public void tick()
      {
@@ -49,7 +48,7 @@
          this.interactionManager.tick();
          --this.respawnInvulnerabilityTicks;
  
-@@ -616,6 +629,7 @@
+@@ -616,6 +628,7 @@
  
              if (!flag && this.respawnInvulnerabilityTicks > 0 && source != DamageSource.OUT_OF_WORLD)
              {
@@ -57,7 +56,7 @@
                  return false;
              }
              else
-@@ -626,6 +640,7 @@
+@@ -626,6 +639,7 @@
  
                      if (entity instanceof EntityPlayer && !this.canAttackPlayer((EntityPlayer)entity))
                      {
@@ -65,7 +64,7 @@
                          return false;
                      }
  
-@@ -636,6 +651,7 @@
+@@ -636,6 +650,7 @@
  
                          if (entity1 instanceof EntityPlayer && !this.canAttackPlayer((EntityPlayer)entity1))
                          {
@@ -73,7 +72,7 @@
                              return false;
                          }
                      }
-@@ -1483,4 +1499,10 @@
+@@ -1483,4 +1498,10 @@
              this.server.getPlayerList().sendInventory(this);
          }
      }

--- a/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
+++ b/patches/net/minecraft/entity/player/EntityPlayerMP.java.patch
@@ -18,17 +18,18 @@
  {
      private static final Logger LOGGER = LogManager.getLogger();
      private String language = "en_US";
-@@ -151,6 +154,9 @@
+@@ -151,6 +154,10 @@
      public int ping;
      public boolean queuedEndExit;
  
 +    //CM
 +    public EntityPlayerActionPack actionPack;
++    public BlockPos posToCheckRaycount = null;
 +
      public EntityPlayerMP(MinecraftServer server, WorldServer worldIn, GameProfile profile, PlayerInteractionManager interactionManagerIn)
      {
          super(worldIn, profile);
-@@ -162,6 +168,9 @@
+@@ -162,6 +169,9 @@
          this.advancements = server.getPlayerList().getPlayerAdvancements(this);
          this.stepHeight = 1.0F;
          this.func_205734_a(worldIn);
@@ -38,7 +39,7 @@
      }
  
      private void func_205734_a(WorldServer p_205734_1_)
-@@ -337,6 +346,9 @@
+@@ -337,6 +347,9 @@
  
      public void tick()
      {
@@ -48,7 +49,7 @@
          this.interactionManager.tick();
          --this.respawnInvulnerabilityTicks;
  
-@@ -616,6 +628,7 @@
+@@ -616,6 +629,7 @@
  
              if (!flag && this.respawnInvulnerabilityTicks > 0 && source != DamageSource.OUT_OF_WORLD)
              {
@@ -56,7 +57,7 @@
                  return false;
              }
              else
-@@ -626,6 +639,7 @@
+@@ -626,6 +640,7 @@
  
                      if (entity instanceof EntityPlayer && !this.canAttackPlayer((EntityPlayer)entity))
                      {
@@ -64,7 +65,7 @@
                          return false;
                      }
  
-@@ -636,6 +650,7 @@
+@@ -636,6 +651,7 @@
  
                          if (entity1 instanceof EntityPlayer && !this.canAttackPlayer((EntityPlayer)entity1))
                          {
@@ -72,7 +73,7 @@
                              return false;
                          }
                      }
-@@ -1483,4 +1498,10 @@
+@@ -1483,4 +1499,10 @@
              this.server.getPlayerList().sendInventory(this);
          }
      }

--- a/src/main/java/carpet/CarpetServer.java
+++ b/src/main/java/carpet/CarpetServer.java
@@ -103,6 +103,7 @@ public class CarpetServer // static for now - easier to handle all around the co
         // TISCM
         LifeTimeCommand.getInstance().registerCommand(dispatcher);
         ChunkRegenCommand.register(dispatcher);
+        RaycountCommand.register(dispatcher);
     }
 
     public static void disconnect()

--- a/src/main/java/carpet/commands/InfoCommand.java
+++ b/src/main/java/carpet/commands/InfoCommand.java
@@ -21,9 +21,11 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
+import net.minecraft.world.dimension.DimensionType;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,6 +37,8 @@ import static net.minecraft.command.Commands.literal;
 
 public class InfoCommand
 {
+    public static HashMap<String, BlockPos[]> posToCheckRaycount = new HashMap<>();
+
     public static void register(CommandDispatcher<CommandSource> dispatcher)
     {
         LiteralArgumentBuilder<CommandSource> command = literal("info").
@@ -139,7 +143,12 @@ public class InfoCommand
     public static void printTntExplosion(Entity e, CommandSource source) {
         if (e instanceof EntityTNTPrimed) {
             try {
-                BlockPos pos = source.asPlayer().posToCheckRaycount;
+                String uuid = source.asPlayer().getUniqueID().toString();
+                if (!posToCheckRaycount.containsKey(uuid)) {
+                    return;
+                }
+                DimensionType dim = source.asPlayer().dimension;
+                BlockPos pos = posToCheckRaycount.get(uuid)[dim.getId() + 1];
                 if (pos == null || !SettingsManager.canUseCommand(source, CarpetSettings.commandRaycount)) {return;}
                 List<ITextComponent> messages = TntInfo.simulateTntExplosion((EntityTNTPrimed) e, pos);
                 Messenger.send(source, messages);

--- a/src/main/java/carpet/commands/InfoCommand.java
+++ b/src/main/java/carpet/commands/InfoCommand.java
@@ -7,14 +7,19 @@ import carpet.settings.SettingsManager;
 import carpet.utils.BlockInfo;
 import carpet.utils.EntityInfo;
 import carpet.utils.Messenger;
+import carpet.utils.TntInfo;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.command.CommandException;
 import net.minecraft.command.CommandSource;
 import net.minecraft.command.arguments.BlockPosArgument;
 import net.minecraft.command.arguments.EntityArgument;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityTNTPrimed;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
 
 import java.util.ArrayList;
@@ -131,6 +136,19 @@ public class InfoCommand
     }
 
 
+    public static void printTntExplosion(Entity e, CommandSource source) {
+        if (e instanceof EntityTNTPrimed) {
+            try {
+                BlockPos pos = source.asPlayer().posToCheckRaycount;
+                if (pos == null || !SettingsManager.canUseCommand(source, CarpetSettings.commandRaycount)) {return;}
+                List<ITextComponent> messages = TntInfo.simulateTntExplosion((EntityTNTPrimed) e, pos);
+                Messenger.send(source, messages);
+            } catch (CommandSyntaxException ex) {
+                throw new CommandException(new TextComponentString("Failed to simulate explosion"));
+            }
+        }
+    }
+
 
     private static int infoEntities(CommandSource source, Collection<? extends Entity> entities, String grep)
     {
@@ -138,6 +156,7 @@ public class InfoCommand
         {
             List<ITextComponent> report = EntityInfo.entityInfo(e, source.getWorld());
             printEntity(report, source, grep);
+            printTntExplosion(e, source);
         }
         return 1;
     }

--- a/src/main/java/carpet/commands/RaycountCommand.java
+++ b/src/main/java/carpet/commands/RaycountCommand.java
@@ -9,6 +9,7 @@ import net.minecraft.command.CommandSource;
 import net.minecraft.command.arguments.BlockPosArgument;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
+import net.minecraft.world.dimension.DimensionType;
 
 import static net.minecraft.command.Commands.argument;
 import static net.minecraft.command.Commands.literal;
@@ -32,7 +33,14 @@ public class RaycountCommand
     private static int updateRaycountCheckPosition(CommandSource source, BlockPos blockPosition) {
         try
         {
-            source.asPlayer().posToCheckRaycount = blockPosition;
+            String uuid = source.asPlayer().getUniqueID().toString();
+            if (!InfoCommand.posToCheckRaycount.containsKey(uuid)) {
+                InfoCommand.posToCheckRaycount.put(uuid, new BlockPos[3]);
+            }
+            BlockPos[] posArray = InfoCommand.posToCheckRaycount.get(uuid);
+            DimensionType dim = source.asPlayer().dimension;
+            posArray[dim.getId() + 1] = blockPosition;
+            InfoCommand.posToCheckRaycount.put(uuid, posArray);
             if (blockPosition != null)
             {
                 source.asPlayer().sendMessage(new TextComponentString(

--- a/src/main/java/carpet/commands/RaycountCommand.java
+++ b/src/main/java/carpet/commands/RaycountCommand.java
@@ -1,0 +1,57 @@
+package carpet.commands;
+
+import carpet.settings.CarpetSettings;
+import carpet.settings.SettingsManager;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.command.CommandSource;
+import net.minecraft.command.arguments.BlockPosArgument;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
+
+import static net.minecraft.command.Commands.argument;
+import static net.minecraft.command.Commands.literal;
+
+public class RaycountCommand
+{
+    public static void register(CommandDispatcher<CommandSource> dispatcher) {
+        LiteralArgumentBuilder<CommandSource> command = literal("raycount").
+                requires((player) -> SettingsManager.canUseCommand(player, CarpetSettings.commandRaycount)).
+                then(argument("block position", BlockPosArgument.blockPos()).
+                        executes((c) -> updateRaycountCheckPosition(
+                                c.getSource(),
+                                BlockPosArgument.getBlockPos(c, "block position")))).
+                then(literal("reset").
+                        executes((c) -> updateRaycountCheckPosition(
+                                c.getSource(),
+                                null)));
+        dispatcher.register(command);
+    }
+
+    private static int updateRaycountCheckPosition(CommandSource source, BlockPos blockPosition) {
+        try
+        {
+            source.asPlayer().posToCheckRaycount = blockPosition;
+            if (blockPosition != null)
+            {
+                source.asPlayer().sendMessage(new TextComponentString(
+                        "Succesfully set the raycount position to x=" + blockPosition.getX() +
+                                " y=" + blockPosition.getY() +
+                                " z=" + blockPosition.getZ()
+                ));
+            }
+            else
+            {
+                source.asPlayer().sendMessage(new TextComponentString(
+                        "Sucessfully reset raycount position"
+                ));
+            }
+        }
+        catch (CommandSyntaxException ignored)
+        {
+            return 0;
+        }
+        return 1;
+    }
+}

--- a/src/main/java/carpet/settings/CarpetSettings.java
+++ b/src/main/java/carpet/settings/CarpetSettings.java
@@ -83,6 +83,13 @@ public class CarpetSettings
     public static String commandVillage = "false";
 
     @Rule(
+            desc = "Enables /raycount to calculate probabilities of a block being broken",
+            extra = "Takes a block position as an argument",
+            category = COMMAND
+    )
+    public static String commandRaycount = "false";
+
+    @Rule(
             desc = "Enables world edit operations",
             category = COMMAND,
             validate = ValidateWorldEdit.class

--- a/src/main/java/carpet/utils/TntInfo.java
+++ b/src/main/java/carpet/utils/TntInfo.java
@@ -88,7 +88,6 @@ public class TntInfo {
             }
             probabilityOfBlockBeingBlownUp = 1D - probabilityOfBlockBeingBlownUp;
         }
-        System.out.println("1");
         List<ITextComponent> messages = new ArrayList<>();
         messages.add(Messenger.c("w  - Position: " +
                         "x=" + pos.getX() +
@@ -97,12 +96,10 @@ public class TntInfo {
                         " has been struck by",
                 "wb  " + amountOfRaysHitting,
                 "w  rays"));
-        System.out.println("2");
         messages.add(Messenger.c("w  - Probability of block being broken is",
                 "wb  " + probabilityOfBlockBeingBlownUp,
                 "w  or",
                 "wb  " + probabilityOfBlockBeingBlownUp * 100 + "%"));
-        System.out.println("3");
         return messages;
     }
 }

--- a/src/main/java/carpet/utils/TntInfo.java
+++ b/src/main/java/carpet/utils/TntInfo.java
@@ -1,0 +1,108 @@
+package carpet.utils;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.item.EntityTNTPrimed;
+import net.minecraft.fluid.IFluidState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TntInfo {
+    public static List<ITextComponent> simulateTntExplosion(EntityTNTPrimed tnt, BlockPos pos) {
+        int amountOfRaysHitting = 0;
+        double explosionHeight = tnt.posY +  (double) (tnt.height / 16F);
+        ArrayList<Double> probabilityOfRayBreakingBlock = new ArrayList<>();
+        float raySizeMultiplier = 1;
+        for (int i = 0; i < 16; ++i) {
+            for (int j = 0; j < 16; ++j) {
+                for (int k = 0; k < 16; ++k) {
+                    if (i == 0 || i == 15 || j == 0 || j == 15 || k == 0 || k == 15) {
+
+                        // calculates how much the ray test position will need to be offset by
+                        double xoffset = (2.0F * i - 15.0F) / 15.0F;
+                        double yoffset = (2.0F * j - 15.0F) / 15.0F;
+                        double zoffset = (2.0F * k - 15.0F) / 15.0F;
+                        double g = Math.sqrt(xoffset * xoffset + yoffset * yoffset + zoffset * zoffset);
+                        xoffset /= g;
+                        yoffset /= g;
+                        zoffset /= g;
+
+                        float rayStrength = (0.7F + raySizeMultiplier * 0.6F) * 4.0F;
+
+                        // first ray test position is at tnt position
+                        double x = tnt.posX;
+                        double y = explosionHeight;
+                        double z = tnt.posZ;
+
+                        while (rayStrength > 0.0F) {
+                            BlockPos blockPos = new BlockPos(x, y, z);
+
+                            // degrade ray strength in case of non air block
+                            IBlockState block = tnt.world.getBlockState(blockPos);
+                            IFluidState fluid = tnt.world.getFluidState(blockPos);
+                            if (!block.isAir() || !fluid.isEmpty()) {
+                                rayStrength -= (Math.max(block.getBlock().getExplosionResistance(), fluid.getExplosionResistance()) + 0.3F) * 0.3F; // raystrength -= (blastresistance + 0.3) * 0.3
+                            }
+
+                            // if ray goes through block then it is added to the list of blocks to explode
+                            if (rayStrength > 0.0F) {
+                                if (blockPos.equals(pos)) {
+                                    amountOfRaysHitting++;
+
+                                    // unwrap ray strength to get min nextFloat value that would break block
+                                    double rayStrengthCopy = rayStrength;
+                                    rayStrengthCopy = 5.2D - rayStrengthCopy;
+                                    rayStrengthCopy /= 4.0D;
+                                    rayStrengthCopy -= 0.7D;
+                                    rayStrengthCopy /= 0.6D;
+                                    // here raystrength needed to blow up block is below minimal of ray (2.8) and so block will be blown up 100% of the time
+                                    if (rayStrengthCopy <= 0) {
+                                        probabilityOfRayBreakingBlock.add(1.0D);
+                                    } else {
+                                        probabilityOfRayBreakingBlock.add(rayStrengthCopy);
+                                    }
+                                    // prevents code from counting a single ray as multiple succesful ones
+                                    rayStrength = 0.0F;
+                                }
+                            }
+
+                            // reduces ray strength (without this ray going through air only would keep looping)
+                            rayStrength -= 0.225F;
+
+                            // moves ray test position to 0.3 blocs further than current along the ray
+                            x += xoffset * 0.3D;
+                            y += yoffset * 0.3D;
+                            z += zoffset * 0.3D;
+                        }
+                    }
+                }
+            }
+        }
+        double probabilityOfBlockBeingBlownUp = 1D;
+        if (!probabilityOfRayBreakingBlock.contains(1D)) {
+            for (double probabilityOfRay : probabilityOfRayBreakingBlock) {
+                probabilityOfRay = 1D - probabilityOfRay;
+                probabilityOfBlockBeingBlownUp *= probabilityOfRay;
+            }
+            probabilityOfBlockBeingBlownUp = 1D - probabilityOfBlockBeingBlownUp;
+        }
+        System.out.println("1");
+        List<ITextComponent> messages = new ArrayList<>();
+        messages.add(Messenger.c("w  - Position: " +
+                        "x=" + pos.getX() +
+                        " y=" + pos.getY() +
+                        " z=" + pos.getZ() +
+                        " has been struck by",
+                "wb  " + amountOfRaysHitting,
+                "w  rays"));
+        System.out.println("2");
+        messages.add(Messenger.c("w  - Probability of block being broken is",
+                "wb  " + probabilityOfBlockBeingBlownUp,
+                "w  or",
+                "wb  " + probabilityOfBlockBeingBlownUp * 100 + "%"));
+        System.out.println("3");
+        return messages;
+    }
+}


### PR DESCRIPTION
To use : enable the raycount command with carpet, select a position with /raycount, then just run /info targetting a primed tnt entity.

This simulates a tnt explosion to get probability of a block being possibly blown up by a tnt